### PR TITLE
feat(readme): animated neon terminal panels for easter eggs

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,33 +231,16 @@ A premium product site with scroll-driven 3D animation — React Three Fiber + T
 
 <details>
 <summary>🛸 <code>decrypt_transmission.exe</code></summary>
-
-```
-        .  *  .   ·   .  ✦   ·   .  *   .  ·  ✦   .
-   ·   ___________      ·       ✦         .    ·
-      /  R I S H  /|        "First, solve the problem.
-     /__________/ |  ✦       Then, write the code."
-     |  ◍  ◍   | |              — and if it breaks at 2am,
-     |   ___    | /   ·          reverse-engineer it till it doesn't.
-     |__________|/
-        ·   .   ✦    ·   .   *   .   ·   ✦   .   *
-```
-
+<br/>
+<img src="https://raw.githubusercontent.com/RISHII7/RISHII7/main/assets/transmission.svg" width="88%" alt="decrypted transmission"/>
 </details>
+
+<br/>
 
 <details>
 <summary>☕ <code>system.diagnostics --about-me</code></summary>
-
-```bash
-$ rishii7 --status
-> uptime ........... shipping since first 'console.log'
-> fuel ............. ▓▓▓▓▓▓▓▓▓░ 92% (coffee)
-> open_tabs ........ 47 (3 are docs, 44 are stackoverflow)
-> current_quest .... make ghost-ai think like a real architect
-> superpower ....... breaking prod apps apart to learn how they tick
-> exit_code ........ 0  // we don't ship red builds here
-```
-
+<br/>
+<img src="https://raw.githubusercontent.com/RISHII7/RISHII7/main/assets/terminal.svg" width="88%" alt="rishii7 --status terminal"/>
 </details>
 
 </div>

--- a/assets/terminal.svg
+++ b/assets/terminal.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 420" width="760" height="420" role="img" aria-label="rishii7 status terminal">
+  <defs>
+    <linearGradient id="win" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d1117"/><stop offset="1" stop-color="#0a0a14"/>
+    </linearGradient>
+    <linearGradient id="bar" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#8b5cf6"/><stop offset="1" stop-color="#22d3ee"/>
+    </linearGradient>
+    <filter id="soft" x="-30%" y="-30%" width="160%" height="160%"><feGaussianBlur stdDeviation="7"/></filter>
+    <style>
+      @keyframes ln{from{opacity:0;transform:translateX(-10px)}to{opacity:1;transform:translateX(0)}}
+      @keyframes blink{50%{opacity:0}}
+      @keyframes shim{0%,100%{opacity:.35}50%{opacity:.9}}
+      .l{opacity:0;animation:ln .5s ease-out forwards}
+      .l1{animation-delay:.15s}.l2{animation-delay:.35s}.l3{animation-delay:.55s}
+      .l4{animation-delay:.75s}.l5{animation-delay:.95s}.l6{animation-delay:1.15s}.l7{animation-delay:1.35s}
+      .cur{animation:blink 1s steps(1) 1.6s infinite}
+      .shim{animation:shim 2.4s ease-in-out infinite}
+      text{font-family:'JetBrains Mono','Fira Code','Consolas',monospace;font-size:16px}
+    </style>
+  </defs>
+
+  <rect x="10" y="10" width="740" height="400" rx="14" fill="#8b5cf6" opacity=".22" filter="url(#soft)"/>
+  <rect x="8" y="8" width="744" height="404" rx="14" fill="url(#win)" stroke="#8b5cf6" stroke-opacity=".45" stroke-width="1.5"/>
+
+  <circle cx="34" cy="32" r="6" fill="#22d3ee"/>
+  <circle cx="56" cy="32" r="6" fill="#8b5cf6"/>
+  <circle cx="78" cy="32" r="6" fill="#3b82f6"/>
+  <text x="104" y="37" fill="#475569" font-size="14" letter-spacing="1">rishii7@echo &#8212; ~/status</text>
+  <line x1="8" y1="52" x2="752" y2="52" stroke="#1f2937"/>
+
+  <text class="l l1" x="32" y="96"><tspan fill="#22d3ee">$</tspan><tspan fill="#e2e8f0"> rishii7 --status</tspan></text>
+
+  <text class="l l2" x="32" y="140"><tspan fill="#8b5cf6">&gt; </tspan><tspan fill="#94a3b8">uptime</tspan><tspan fill="#334155"> ........... </tspan><tspan fill="#e2e8f0">shipping since first </tspan><tspan fill="#22d3ee">'console.log'</tspan></text>
+
+  <text class="l l3" x="32" y="184"><tspan fill="#8b5cf6">&gt; </tspan><tspan fill="#94a3b8">fuel</tspan><tspan fill="#334155"> ............. </tspan></text>
+  <g class="l l3">
+    <rect x="228" y="171" width="196" height="15" rx="7" fill="#1f2937"/>
+    <rect x="228" y="171" width="0" height="15" rx="7" fill="url(#bar)">
+      <animate attributeName="width" from="0" to="180" dur="1.6s" begin="1s" fill="freeze"/>
+    </rect>
+    <rect class="shim" x="228" y="171" width="180" height="15" rx="7" fill="#ffffff" opacity=".0"/>
+    <text x="436" y="184" fill="#22d3ee">92%</text>
+    <text x="486" y="184" fill="#64748b">(coffee)</text>
+  </g>
+
+  <text class="l l4" x="32" y="228"><tspan fill="#8b5cf6">&gt; </tspan><tspan fill="#94a3b8">open_tabs</tspan><tspan fill="#334155"> ........ </tspan><tspan fill="#e2e8f0">47</tspan><tspan fill="#64748b">  &#183;  3 docs, 44 stackoverflow</tspan></text>
+
+  <text class="l l5" x="32" y="272"><tspan fill="#8b5cf6">&gt; </tspan><tspan fill="#94a3b8">quest</tspan><tspan fill="#334155"> ............ </tspan><tspan fill="#e2e8f0">teach </tspan><tspan fill="#8b5cf6">ghost-ai</tspan><tspan fill="#e2e8f0"> to think like an architect</tspan></text>
+
+  <text class="l l6" x="32" y="316"><tspan fill="#8b5cf6">&gt; </tspan><tspan fill="#94a3b8">superpower</tspan><tspan fill="#334155"> ....... </tspan><tspan fill="#e2e8f0">breaking prod apps apart to learn them</tspan></text>
+
+  <text class="l l7" x="32" y="360"><tspan fill="#8b5cf6">&gt; </tspan><tspan fill="#94a3b8">exit_code</tspan><tspan fill="#334155"> ........ </tspan><tspan fill="#22d3ee">0</tspan><tspan fill="#64748b">   //  we don't ship red builds</tspan></text>
+
+  <rect class="cur" x="32" y="384" width="10" height="18" fill="#22d3ee"/>
+</svg>

--- a/assets/transmission.svg
+++ b/assets/transmission.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 300" width="760" height="300" role="img" aria-label="decrypted transmission">
+  <defs>
+    <linearGradient id="tw" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d1117"/><stop offset="1" stop-color="#0a0a14"/>
+    </linearGradient>
+    <radialGradient id="dome" cx=".5" cy=".3" r=".7">
+      <stop offset="0" stop-color="#a5f3fc"/><stop offset="1" stop-color="#22d3ee"/>
+    </radialGradient>
+    <linearGradient id="hull" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/><stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <filter id="q" x="-20%" y="-40%" width="140%" height="180%">
+      <feGaussianBlur stdDeviation="3.5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="blur"><feGaussianBlur stdDeviation="6"/></filter>
+    <style>
+      @keyframes blink{50%{opacity:.15}}
+      @keyframes tw{0%,100%{opacity:.2}50%{opacity:1}}
+      @keyframes rise{from{opacity:0;transform:translateY(10px)}to{opacity:1;transform:translateY(0)}}
+      @keyframes scan{0%{transform:translateY(0)}100%{transform:translateY(284px)}}
+      @keyframes hover{0%,100%{transform:translateY(0)}50%{transform:translateY(-8px)}}
+      .rec{animation:blink 1.1s steps(1) infinite}
+      .q1{opacity:0;animation:rise .8s ease-out .3s forwards}
+      .q2{opacity:0;animation:rise .8s ease-out .6s forwards}
+      .sig{opacity:0;animation:rise .8s ease-out .9s forwards}
+      .scan{animation:scan 5s linear infinite}
+      .ship{animation:hover 4s ease-in-out infinite}
+      .st{animation:tw 3s ease-in-out infinite}
+    </style>
+  </defs>
+
+  <rect x="10" y="10" width="740" height="280" rx="14" fill="#22d3ee" opacity=".18" filter="url(#blur)"/>
+  <rect x="8" y="8" width="744" height="284" rx="14" fill="url(#tw)" stroke="#22d3ee" stroke-opacity=".4" stroke-width="1.5"/>
+
+  <g fill="#cbd5e1">
+    <circle class="st" cx="70" cy="70" r="1.6"/>
+    <circle class="st" cx="150" cy="220" r="1.4" style="animation-delay:.6s"/>
+    <circle class="st" cx="300" cy="60" r="1.8" style="animation-delay:1.1s" fill="#22d3ee"/>
+    <circle class="st" cx="470" cy="230" r="1.5" style="animation-delay:.3s"/>
+    <circle class="st" cx="560" cy="70" r="1.4" style="animation-delay:1.4s" fill="#8b5cf6"/>
+    <circle class="st" cx="700" cy="210" r="1.7" style="animation-delay:.9s"/>
+    <circle class="st" cx="120" cy="140" r="1.3" style="animation-delay:2s"/>
+    <circle class="st" cx="410" cy="120" r="1.3" style="animation-delay:1.7s" fill="#22d3ee"/>
+  </g>
+
+  <circle class="rec" cx="34" cy="36" r="6" fill="#f43f5e"/>
+  <text x="50" y="41" fill="#22d3ee" font-family="'JetBrains Mono','Consolas',monospace" font-size="13" letter-spacing="3">TRANSMISSION DECRYPTED</text>
+
+  <g class="ship" transform="translate(636 74)">
+    <ellipse cx="0" cy="34" rx="46" ry="9" fill="#22d3ee" opacity=".18" filter="url(#blur)"/>
+    <path d="M-58 0 C-58 -11 58 -11 58 0 C58 9 -58 9 -58 0 Z" fill="url(#hull)" stroke="#22d3ee" stroke-opacity=".6"/>
+    <ellipse cx="0" cy="-2" rx="22" ry="15" fill="url(#dome)" opacity=".95"/>
+    <circle cx="-34" cy="2" r="3" fill="#22d3ee"><animate attributeName="opacity" values="1;.2;1" dur="1.2s" begin="0s" repeatCount="indefinite"/></circle>
+    <circle cx="-12" cy="5" r="3" fill="#8b5cf6"><animate attributeName="opacity" values="1;.2;1" dur="1.2s" begin=".3s" repeatCount="indefinite"/></circle>
+    <circle cx="12" cy="5" r="3" fill="#22d3ee"><animate attributeName="opacity" values="1;.2;1" dur="1.2s" begin=".6s" repeatCount="indefinite"/></circle>
+    <circle cx="34" cy="2" r="3" fill="#8b5cf6"><animate attributeName="opacity" values="1;.2;1" dur="1.2s" begin=".9s" repeatCount="indefinite"/></circle>
+  </g>
+
+  <text class="q1" x="44" y="150" fill="#e2e8f0" filter="url(#q)" font-family="'Segoe UI',system-ui,sans-serif" font-size="24" font-weight="600">&#8220;First, solve the problem. Then, write the code.&#8221;</text>
+  <text class="q2" x="44" y="188" fill="#94a3b8" font-family="'Segoe UI',system-ui,sans-serif" font-size="15" font-style="italic">&#8212; and if it breaks at 2am, reverse-engineer it till it doesn&#8217;t.</text>
+
+  <text class="sig" x="724" y="262" text-anchor="end" fill="#64748b" font-family="'JetBrains Mono','Consolas',monospace" font-size="12" letter-spacing="2">&#9702; signal decoded &#183; RISH-7 &#9702;</text>
+
+  <rect class="scan" x="8" y="8" width="744" height="2" fill="#22d3ee" opacity=".18"/>
+</svg>


### PR DESCRIPTION
Replaces the two plain code-block easter eggs with custom animated SVG panels (theme-matched violet/cyan):

- **transmission.svg** — decrypted-transmission card: twinkling starfield, drifting neon UFO with blinking underlights, glowing quote, sweeping scanline
- **terminal.svg** — glowing terminal window rendering `rishii7 --status` with a staggered line reveal, animated fuel bar, and blinking cursor

Both animate via GitHub's camo proxy (CSS keyframes + SMIL). Ambient loops (cursor, twinkle, ship hover, scanline) keep them alive whenever the `<details>` is opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new collapsible Easter egg item with an accompanying image.
  * Updated an existing collapsible section to display a new visual element instead of text-heavy content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->